### PR TITLE
Add static evaluation page template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # llm_env
+
+This repository contains a minimal Django project used for experiments with large language models.
+
+## Evaluation page
+
+Run the Django server and open `/evaluation/` to view a simple UI for rating the output of a language model.

--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LLM 평가 페이지</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+    <style>
+        body { background-color: #f0f2f5; }
+        .card { border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); }
+        .accordion-button:not(.collapsed) { background-color: #e7f1ff; color: #0c63e4; }
+        .json-key {
+            font-weight: bold;
+            color: #555;
+            width: 25%;
+        }
+        .list-group-item.active {
+            background-color: #0d6efd;
+            border-color: #0d6efd;
+        }
+        .evaluation-box {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem;
+            background-color: #fff;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+        }
+        .evaluation-box .form-label { margin-bottom: 0.25rem; font-weight: bold; font-size: 0.9rem; }
+        .rating-stars { cursor: pointer; color: #ccc; }
+        .rating-stars .fa-star:hover, .rating-stars .fa-star.selected { color: #ffc107; }
+    </style>
+</head>
+<body>
+
+<div class="container-fluid p-3 p-md-4">
+    <div class="row">
+        <main class="col-md-9">
+            <div class="accordion mb-3" id="promptAccordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSystem">
+                            System Prompt
+                        </button>
+                    </h2>
+                    <div id="collapseSystem" class="accordion-collapse collapse show" data-bs-parent="#promptAccordion">
+                        <div class="accordion-body">
+                            You are a helpful assistant that analyzes medical images.
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseUser">
+                            User Prompt
+                        </button>
+                    </h2>
+                    <div id="collapseUser" class="accordion-collapse collapse" data-bs-parent="#promptAccordion">
+                        <div class="accordion-body">
+                            Analyze the attached chest X-ray image and identify any abnormalities.
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-3">
+                <div class="card-header fw-bold">Image</div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-4">
+                            <img src="https://i.imgur.com/gGRgWf8.jpeg" class="img-fluid rounded" alt="Chest X-ray 1">
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-3">
+                <div class="card-header fw-bold">LLM Result</div>
+                <div class="card-body">
+                    <table class="table table-bordered table-striped">
+                        <tbody>
+                            <tr>
+                                <td class="json-key">finding</td>
+                                <td>Possible signs of pneumonia in the lower right lobe.</td>
+                            </tr>
+                            <tr>
+                                <td class="json-key">location</td>
+                                <td>[ "right lower lobe" ]</td>
+                            </tr>
+                            <tr>
+                                <td class="json-key">confidence</td>
+                                <td>0.85</td>
+                            </tr>
+                            <tr>
+                                <td class="json-key">recommendation</td>
+                                <td>Suggest further CT scan for confirmation.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="evaluation-box">
+                <div>
+                    <label class="form-label">Agreement</label>
+                    <div class="btn-group" role="group">
+                        <input type="radio" class="btn-check" name="agreement" id="agreement-o" autocomplete="off">
+                        <label class="btn btn-outline-success" for="agreement-o">O</label>
+                        <input type="radio" class="btn-check" name="agreement" id="agreement-x" autocomplete="off">
+                        <label class="btn btn-outline-danger" for="agreement-x">X</label>
+                    </div>
+                </div>
+                <div>
+                    <label class="form-label">Quality</label>
+                    <div class="rating-stars h4 m-0">
+                        <i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i>
+                    </div>
+                </div>
+                <div class="flex-grow-1">
+                    <label class="form-label">Comment</label>
+                    <input type="text" class="form-control" placeholder="Comment">
+                </div>
+                <div>
+                    <label class="form-label d-block" style="opacity: 0;">.</label>
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+            </div>
+        </main>
+        <aside class="col-md-3">
+            <div class="card">
+                <div class="card-header fw-bold">LLM Inference list</div>
+                <ul class="list-group list-group-flush">
+                    <a href="#" class="list-group-item list-group-item-action active" aria-current="true">1. CB-321(JLK-CMB)</a>
+                    <a href="#" class="list-group-item list-group-item-action">2. BD-321(JLK-BDW)</a>
+                    <a href="#" class="list-group-item list-group-item-action">3. XY-101(JLK-XYZ)</a>
+                    <a href="#" class="list-group-item list-group-item-action">4. QA-007(JLK-QAZ)</a>
+                </ul>
+            </div>
+        </aside>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    document.querySelectorAll('.rating-stars .fa-star').forEach(star => {
+        star.addEventListener('click', function() {
+            let parent = this.parentElement;
+            parent.querySelectorAll('.fa-star').forEach(s => s.classList.remove('selected'));
+            this.classList.add('selected');
+        });
+    });
+</script>
+</body>
+</html>

--- a/llm_env/evaluation/urls.py
+++ b/llm_env/evaluation/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.evaluation_view, name='evaluation'),
+]

--- a/llm_env/evaluation/views.py
+++ b/llm_env/evaluation/views.py
@@ -1,3 +1,6 @@
 from django.shortcuts import render
 
-# Create your views here.
+
+def evaluation_view(request):
+    """Render a static evaluation page for testing."""
+    return render(request, 'evaluation/evaluation.html')

--- a/llm_env/llm_env/urls.py
+++ b/llm_env/llm_env/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('evaluation/', include('evaluation.urls')),
 ]


### PR DESCRIPTION
## Summary
- add evaluation page template
- register evaluation app URLs
- provide simple evaluation view
- update README with usage notes

## Testing
- `python llm_env/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6879f1cd78bc8322a969728e3b30f2fc