### PR TITLE
Connect inference results to evaluation

### DIFF
--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -47,7 +47,7 @@
                     </h2>
                     <div id="collapseSystem" class="accordion-collapse collapse show" data-bs-parent="#promptAccordion">
                         <div class="accordion-body">
-                            You are a helpful assistant that analyzes medical images.
+                            {{ system_prompt }}
                         </div>
                     </div>
                 </div>
@@ -59,7 +59,7 @@
                     </h2>
                     <div id="collapseUser" class="accordion-collapse collapse" data-bs-parent="#promptAccordion">
                         <div class="accordion-body">
-                            Analyze the attached chest X-ray image and identify any abnormalities.
+                            {{ user_prompt }}
                         </div>
                     </div>
                 </div>
@@ -69,7 +69,7 @@
                 <div class="card-body">
                     <div class="row">
                         <div class="col-md-4">
-                            <img src="https://i.imgur.com/gGRgWf8.jpeg" class="img-fluid rounded" alt="Chest X-ray 1">
+                            <img src="{{ image_url }}" class="img-fluid rounded" alt="Image">
                         </div>
                     </div>
                 </div>
@@ -79,22 +79,12 @@
                 <div class="card-body">
                     <table class="table table-bordered table-striped">
                         <tbody>
+                        {% for key, value in llm_result.items %}
                             <tr>
-                                <td class="json-key">finding</td>
-                                <td>Possible signs of pneumonia in the lower right lobe.</td>
+                                <td class="json-key">{{ key }}</td>
+                                <td>{{ value }}</td>
                             </tr>
-                            <tr>
-                                <td class="json-key">location</td>
-                                <td>[ "right lower lobe" ]</td>
-                            </tr>
-                            <tr>
-                                <td class="json-key">confidence</td>
-                                <td>0.85</td>
-                            </tr>
-                            <tr>
-                                <td class="json-key">recommendation</td>
-                                <td>Suggest further CT scan for confirmation.</td>
-                            </tr>
+                        {% endfor %}
                         </tbody>
                     </table>
                 </div>
@@ -129,10 +119,13 @@
             <div class="card">
                 <div class="card-header fw-bold">LLM Inference list</div>
                 <ul class="list-group list-group-flush">
-                    <a href="#" class="list-group-item list-group-item-action active" aria-current="true">1. CB-321(JLK-CMB)</a>
-                    <a href="#" class="list-group-item list-group-item-action">2. BD-321(JLK-BDW)</a>
-                    <a href="#" class="list-group-item list-group-item-action">3. XY-101(JLK-XYZ)</a>
-                    <a href="#" class="list-group-item list-group-item-action">4. QA-007(JLK-QAZ)</a>
+                {% for item in inference_list %}
+                    <a href="{% url 'evaluation_detail' item.pk %}" class="list-group-item list-group-item-action {% if item.pk == selected_id %}active{% endif %}">
+                        {{ forloop.counter }}. {{ item.created_at|date:"Y-m-d H:i" }}
+                    </a>
+                {% empty %}
+                    <li class="list-group-item">No inference results.</li>
+                {% endfor %}
                 </ul>
             </div>
         </aside>

--- a/llm_env/evaluation/urls.py
+++ b/llm_env/evaluation/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.evaluation_view, name='evaluation'),
+    path('<int:pk>/', views.evaluation_view, name='evaluation_detail'),
 ]

--- a/llm_env/evaluation/views.py
+++ b/llm_env/evaluation/views.py
@@ -1,6 +1,47 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
+
+from inference.models import InferenceResult
 
 
-def evaluation_view(request):
-    """Render a static evaluation page for testing."""
-    return render(request, 'evaluation/evaluation.html')
+def evaluation_view(request, pk=None):
+    """Render the evaluation page using the latest inference result."""
+
+    result = None
+    if pk is not None:
+        result = get_object_or_404(InferenceResult, pk=pk)
+    else:
+        result = InferenceResult.objects.order_by('-created_at').first()
+
+    inference_list = InferenceResult.objects.order_by('-created_at')[:10]
+
+    context = {
+        'system_prompt': (
+            result.system_prompt
+            if result
+            else 'You are a helpful assistant that analyzes medical images.'
+        ),
+        'user_prompt': (
+            result.user_prompt
+            if result
+            else 'Analyze the attached chest X-ray image and identify any abnormalities.'
+        ),
+        'image_url': (
+            result.image_url
+            if result
+            else 'https://i.imgur.com/gGRgWf8.jpeg'
+        ),
+        'llm_result': (
+            result.llm_output
+            if result
+            else {
+                'finding': 'Possible signs of pneumonia in the lower right lobe.',
+                'location': ['right lower lobe'],
+                'confidence': 0.85,
+                'recommendation': 'Suggest further CT scan for confirmation.',
+            }
+        ),
+        'inference_list': inference_list,
+        'selected_id': result.pk if result else None,
+    }
+
+    return render(request, 'evaluation/evaluation.html', context)

--- a/llm_env/inference/migrations/0001_initial.py
+++ b/llm_env/inference/migrations/0001_initial.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='InferenceResult',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('system_prompt', models.TextField()),
+                ('user_prompt', models.TextField()),
+                ('image_url', models.URLField()),
+                ('llm_output', models.JSONField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+    ]

--- a/llm_env/inference/models.py
+++ b/llm_env/inference/models.py
@@ -1,3 +1,15 @@
 from django.db import models
 
-# Create your models here.
+
+class InferenceResult(models.Model):
+    """Simple model to store an LLM inference output."""
+
+    system_prompt = models.TextField()
+    user_prompt = models.TextField()
+    image_url = models.URLField()
+    llm_output = models.JSONField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"Inference #{self.pk}"
+

--- a/llm_env/inference/urls.py
+++ b/llm_env/inference/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('run/', views.run_inference, name='run_inference'),
+]

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -1,3 +1,22 @@
-from django.shortcuts import render
+from django.shortcuts import redirect
 
-# Create your views here.
+from .models import InferenceResult
+
+
+def run_inference(request):
+    """Create a sample inference result and redirect to evaluation."""
+
+    result = InferenceResult.objects.create(
+        system_prompt="You are a helpful assistant that analyzes medical images.",
+        user_prompt="Analyze the attached chest X-ray image and identify any abnormalities.",
+        image_url="https://i.imgur.com/gGRgWf8.jpeg",
+        llm_output={
+            "finding": "Possible signs of pneumonia in the lower right lobe.",
+            "location": ["right lower lobe"],
+            "confidence": 0.85,
+            "recommendation": "Suggest further CT scan for confirmation.",
+        },
+    )
+
+    return redirect("evaluation_detail", pk=result.pk)
+

--- a/llm_env/llm_env/urls.py
+++ b/llm_env/llm_env/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('evaluation/', include('evaluation.urls')),
+    path('inference/', include('inference.urls')),
 ]


### PR DESCRIPTION
## Summary
- create `InferenceResult` model and migration
- add an inference endpoint that records a sample inference and redirects to evaluation
- show latest inference data on the evaluation page
- allow selecting past results from a sidebar list
- expose the new inference URLs via project URL conf

## Testing
- `python3 llm_env/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6879f3ba6c3083228ab3afb49a7f719d