### PR TITLE
Add inference form page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a minimal Django project used for experiments with large language models.
 
+## Inference page
+
+Open `/inference/` to generate a new `InferenceResult`. The page provides a simple form for entering the system prompt, user prompt and an image URL. Submitting the form creates a record and redirects to the evaluation page for that result.
+
 ## Evaluation page
 
 Run the Django server and open `/evaluation/` to view a simple UI for rating the output of a language model.

--- a/llm_env/inference/templates/inference/inference_form.html
+++ b/llm_env/inference/templates/inference/inference_form.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>LLM Inference</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-4">
+    <h1 class="mb-4">LLM Inference</h1>
+    <form method="post">
+        {% csrf_token %}
+        <div class="mb-3">
+            <label class="form-label">System Prompt</label>
+            <textarea name="system_prompt" class="form-control" rows="3">{{ system_prompt }}</textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">User Prompt</label>
+            <textarea name="user_prompt" class="form-control" rows="3">{{ user_prompt }}</textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Image URL</label>
+            <input type="text" name="image_url" class="form-control" value="{{ image_url }}">
+        </div>
+        <button type="submit" class="btn btn-primary">Run</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/llm_env/inference/urls.py
+++ b/llm_env/inference/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('', views.inference_form, name='inference_form'),
     path('run/', views.run_inference, name='run_inference'),
 ]

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 
 from .models import InferenceResult
 
@@ -19,4 +19,37 @@ def run_inference(request):
     )
 
     return redirect("evaluation_detail", pk=result.pk)
+
+
+def inference_form(request):
+    """Simple page to create an inference result using form inputs."""
+
+    defaults = {
+        "system_prompt": "You are a helpful assistant that analyzes medical images.",
+        "user_prompt": "Analyze the attached chest X-ray image and identify any abnormalities.",
+        "image_url": "https://i.imgur.com/gGRgWf8.jpeg",
+    }
+
+    if request.method == "POST":
+        system_prompt = request.POST.get("system_prompt", defaults["system_prompt"])
+        user_prompt = request.POST.get("user_prompt", defaults["user_prompt"])
+        image_url = request.POST.get("image_url", defaults["image_url"])
+
+        llm_output = {
+            "finding": "Possible signs of pneumonia in the lower right lobe.",
+            "location": ["right lower lobe"],
+            "confidence": 0.85,
+            "recommendation": "Suggest further CT scan for confirmation.",
+        }
+
+        result = InferenceResult.objects.create(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            image_url=image_url,
+            llm_output=llm_output,
+        )
+
+        return redirect("evaluation_detail", pk=result.pk)
+
+    return render(request, "inference/inference_form.html", defaults)
 


### PR DESCRIPTION
## Summary
- add `/inference/` page with a simple form to create `InferenceResult`
- hook the new view up in URLs
- document inference page in README

## Testing
- `python llm_env/manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6879f4f888648322924509b2b8fcd90c