### PR TITLE
Improve inference page with multi-image input

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a minimal Django project used for experiments with large language models.
 
+## Inference page
+
+Open `/inference/` to generate a new `InferenceResult`. The page now lets you enter the system prompt, a user prompt and any number of image URLs. Add more image URL fields with the **+** button. Submitting the form creates a record and redirects to its evaluation page.
+
 ## Evaluation page
 
 Run the Django server and open `/evaluation/` to view a simple UI for rating the output of a language model.

--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -65,12 +65,14 @@
                 </div>
             </div>
             <div class="card mb-3">
-                <div class="card-header fw-bold">Image</div>
+                <div class="card-header fw-bold">Images</div>
                 <div class="card-body">
-                    <div class="row">
+                    <div class="row g-3">
+                    {% for img in image_urls %}
                         <div class="col-md-4">
-                            <img src="{{ image_url }}" class="img-fluid rounded" alt="Image">
+                            <img src="{{ img }}" class="img-fluid rounded" alt="Image">
                         </div>
+                    {% endfor %}
                     </div>
                 </div>
             </div>

--- a/llm_env/evaluation/views.py
+++ b/llm_env/evaluation/views.py
@@ -25,10 +25,10 @@ def evaluation_view(request, pk=None):
             if result
             else 'Analyze the attached chest X-ray image and identify any abnormalities.'
         ),
-        'image_url': (
-            result.image_url
+        'image_urls': (
+            result.image_urls
             if result
-            else 'https://i.imgur.com/gGRgWf8.jpeg'
+            else ['https://i.imgur.com/gGRgWf8.jpeg']
         ),
         'llm_result': (
             result.llm_output

--- a/llm_env/inference/migrations/0002_image_urls.py
+++ b/llm_env/inference/migrations/0002_image_urls.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('inference', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='inferenceresult',
+            name='image_url',
+        ),
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='image_urls',
+            field=models.JSONField(default=list),
+        ),
+    ]

--- a/llm_env/inference/models.py
+++ b/llm_env/inference/models.py
@@ -6,7 +6,9 @@ class InferenceResult(models.Model):
 
     system_prompt = models.TextField()
     user_prompt = models.TextField()
-    image_url = models.URLField()
+    # Allow storing multiple image URLs instead of a single one
+    # Keep data simple by using JSON list of URLs
+    image_urls = models.JSONField(default=list)
     llm_output = models.JSONField()
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/llm_env/inference/templates/inference/inference_form.html
+++ b/llm_env/inference/templates/inference/inference_form.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>LLM Inference</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-4">
+    <h1 class="mb-4">LLM Inference</h1>
+    <form method="post">
+        {% csrf_token %}
+        <div class="mb-3">
+            <label class="form-label">System Prompt</label>
+            <textarea name="system_prompt" class="form-control" rows="3">{{ system_prompt }}</textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">User Prompt</label>
+            <textarea name="user_prompt" class="form-control" rows="3">{{ user_prompt }}</textarea>
+        </div>
+        <div class="mb-3" id="image-container">
+            <label class="form-label">Image URLs</label>
+            <div class="input-group mb-2">
+                <input type="text" name="image_urls" class="form-control" placeholder="https://" value="{{ image_urls.0 }}">
+                <button class="btn btn-outline-secondary" type="button" id="add-image">+</button>
+            </div>
+            {% for img in image_urls|slice:'1:' %}
+            <div class="input-group mb-2">
+                <input type="text" name="image_urls" class="form-control" value="{{ img }}">
+            </div>
+            {% endfor %}
+        </div>
+        <button type="submit" class="btn btn-primary">Run</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.getElementById('add-image').addEventListener('click', function() {
+    const container = document.getElementById('image-container');
+    const group = document.createElement('div');
+    group.className = 'input-group mb-2';
+    group.innerHTML = '<input type="text" name="image_urls" class="form-control" placeholder="https://">';
+    container.appendChild(group);
+});
+</script>
+</body>
+</html>

--- a/llm_env/inference/urls.py
+++ b/llm_env/inference/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('', views.inference_form, name='inference_form'),
     path('run/', views.run_inference, name='run_inference'),
 ]

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 
 from .models import InferenceResult
 
@@ -9,7 +9,7 @@ def run_inference(request):
     result = InferenceResult.objects.create(
         system_prompt="You are a helpful assistant that analyzes medical images.",
         user_prompt="Analyze the attached chest X-ray image and identify any abnormalities.",
-        image_url="https://i.imgur.com/gGRgWf8.jpeg",
+        image_urls=["https://i.imgur.com/gGRgWf8.jpeg"],
         llm_output={
             "finding": "Possible signs of pneumonia in the lower right lobe.",
             "location": ["right lower lobe"],
@@ -19,4 +19,39 @@ def run_inference(request):
     )
 
     return redirect("evaluation_detail", pk=result.pk)
+
+
+def inference_form(request):
+    """Simple page to create an inference result using form inputs."""
+
+    defaults = {
+        "system_prompt": "You are a helpful assistant that analyzes medical images.",
+        "user_prompt": "Analyze the attached chest X-ray image and identify any abnormalities.",
+        "image_urls": ["https://i.imgur.com/gGRgWf8.jpeg"],
+    }
+
+    if request.method == "POST":
+        system_prompt = request.POST.get("system_prompt", defaults["system_prompt"])
+        user_prompt = request.POST.get("user_prompt", defaults["user_prompt"])
+        image_urls = [url for url in request.POST.getlist("image_urls") if url]
+        if not image_urls:
+            image_urls = defaults["image_urls"]
+
+        llm_output = {
+            "finding": "Possible signs of pneumonia in the lower right lobe.",
+            "location": ["right lower lobe"],
+            "confidence": 0.85,
+            "recommendation": "Suggest further CT scan for confirmation.",
+        }
+
+        result = InferenceResult.objects.create(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            image_urls=image_urls,
+            llm_output=llm_output,
+        )
+
+        return redirect("evaluation_detail", pk=result.pk)
+
+    return render(request, "inference/inference_form.html", defaults)
 


### PR DESCRIPTION
## Summary
- support multiple image URLs in inference form
- update model to store JSON list of images
- show all images on evaluation page

## Testing
- `python llm_env/manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6879f4f888648322924509b2b8fcd90c