### PR TITLE
Add support for multiple images in inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a minimal Django project used for experiments with larg
 
 ## Inference page
 
-Open `/inference/` to generate a new `InferenceResult`. The page provides a simple form for entering the system prompt, user prompt and an image URL. Submitting the form creates a record and redirects to the evaluation page for that result.
+Open `/inference/` to generate a new `InferenceResult`. The page provides a simple form for entering the system prompt, an optional user prompt and one or more image URLs. Submitting the form creates a record and redirects to the evaluation page for that result.
 
 ## Evaluation page
 

--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -68,9 +68,11 @@
                 <div class="card-header fw-bold">Image</div>
                 <div class="card-body">
                     <div class="row">
-                        <div class="col-md-4">
-                            <img src="{{ image_url }}" class="img-fluid rounded" alt="Image">
+                        {% for url in image_urls %}
+                        <div class="col-md-4 mb-3">
+                            <img src="{{ url }}" class="img-fluid rounded" alt="Image">
                         </div>
+                        {% endfor %}
                     </div>
                 </div>
             </div>

--- a/llm_env/evaluation/views.py
+++ b/llm_env/evaluation/views.py
@@ -25,10 +25,10 @@ def evaluation_view(request, pk=None):
             if result
             else 'Analyze the attached chest X-ray image and identify any abnormalities.'
         ),
-        'image_url': (
-            result.image_url
+        'image_urls': (
+            result.image_urls
             if result
-            else 'https://i.imgur.com/gGRgWf8.jpeg'
+            else ['https://i.imgur.com/gGRgWf8.jpeg']
         ),
         'llm_result': (
             result.llm_output

--- a/llm_env/inference/migrations/0002_multi_images.py
+++ b/llm_env/inference/migrations/0002_multi_images.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inference', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='image_urls',
+            field=models.JSONField(default=list, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='inferenceresult',
+            name='user_prompt',
+            field=models.TextField(blank=True),
+        ),
+        migrations.RemoveField(
+            model_name='inferenceresult',
+            name='image_url',
+        ),
+    ]

--- a/llm_env/inference/models.py
+++ b/llm_env/inference/models.py
@@ -5,8 +5,8 @@ class InferenceResult(models.Model):
     """Simple model to store an LLM inference output."""
 
     system_prompt = models.TextField()
-    user_prompt = models.TextField()
-    image_url = models.URLField()
+    user_prompt = models.TextField(blank=True)
+    image_urls = models.JSONField(default=list, blank=True)
     llm_output = models.JSONField()
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/llm_env/inference/templates/inference/inference_form.html
+++ b/llm_env/inference/templates/inference/inference_form.html
@@ -18,13 +18,30 @@
             <label class="form-label">User Prompt</label>
             <textarea name="user_prompt" class="form-control" rows="3">{{ user_prompt }}</textarea>
         </div>
-        <div class="mb-3">
-            <label class="form-label">Image URL</label>
-            <input type="text" name="image_url" class="form-control" value="{{ image_url }}">
+        <div id="image-fields">
+            <div class="mb-3">
+                <label class="form-label">Image URL</label>
+                <input type="text" name="image_url" class="form-control" value="{{ image_urls|first }}">
+            </div>
+            {% for url in image_urls|slice:'1:' %}
+            <div class="mb-3">
+                <input type="text" name="image_url" class="form-control" value="{{ url }}">
+            </div>
+            {% endfor %}
         </div>
+        <button type="button" id="add-image" class="btn btn-secondary mb-3">Add Image</button>
         <button type="submit" class="btn btn-primary">Run</button>
     </form>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.getElementById('add-image').addEventListener('click', function() {
+    const container = document.getElementById('image-fields');
+    const div = document.createElement('div');
+    div.className = 'mb-3';
+    div.innerHTML = '<input type="text" name="image_url" class="form-control" placeholder="Image URL">';
+    container.appendChild(div);
+});
+</script>
 </body>
 </html>

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -9,7 +9,7 @@ def run_inference(request):
     result = InferenceResult.objects.create(
         system_prompt="You are a helpful assistant that analyzes medical images.",
         user_prompt="Analyze the attached chest X-ray image and identify any abnormalities.",
-        image_url="https://i.imgur.com/gGRgWf8.jpeg",
+        image_urls=["https://i.imgur.com/gGRgWf8.jpeg"],
         llm_output={
             "finding": "Possible signs of pneumonia in the lower right lobe.",
             "location": ["right lower lobe"],
@@ -27,13 +27,15 @@ def inference_form(request):
     defaults = {
         "system_prompt": "You are a helpful assistant that analyzes medical images.",
         "user_prompt": "Analyze the attached chest X-ray image and identify any abnormalities.",
-        "image_url": "https://i.imgur.com/gGRgWf8.jpeg",
+        "image_urls": ["https://i.imgur.com/gGRgWf8.jpeg"],
     }
 
     if request.method == "POST":
         system_prompt = request.POST.get("system_prompt", defaults["system_prompt"])
-        user_prompt = request.POST.get("user_prompt", defaults["user_prompt"])
-        image_url = request.POST.get("image_url", defaults["image_url"])
+        user_prompt = request.POST.get("user_prompt", "")
+        image_urls = [url for url in request.POST.getlist("image_url") if url]
+        if not image_urls:
+            image_urls = defaults["image_urls"]
 
         llm_output = {
             "finding": "Possible signs of pneumonia in the lower right lobe.",
@@ -45,7 +47,7 @@ def inference_form(request):
         result = InferenceResult.objects.create(
             system_prompt=system_prompt,
             user_prompt=user_prompt,
-            image_url=image_url,
+            image_urls=image_urls,
             llm_output=llm_output,
         )
 


### PR DESCRIPTION
## Summary
- allow empty user prompts and multiple image URLs
- display all images on the evaluation page
- update form UI with dynamic image inputs
- document new behaviour
- add migration for new fields

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879f864528c8322a6f80cbeb91706cc