### PR TITLE
Add lesion location fields and collapsible sections

### DIFF
--- a/llm_env/evaluation/admin.py
+++ b/llm_env/evaluation/admin.py
@@ -9,6 +9,21 @@ class EvaluationAdmin(admin.ModelAdmin):
     """
     Evaluation 모델을 위한 Admin 페이지 설정
     """
-    list_display = ('id', 'inference_result', 'evaluator', 'agreement', 'quality', 'created_at') # 목록에 보여줄 필드를 지정합니다.
-    list_filter = ('agreement', 'quality', 'evaluator') # 필터링할 필드를 지정합니다.
+    list_display = (
+        'id',
+        'inference_result',
+        'evaluator',
+        'agreement',
+        'quality',
+        'lesion_vessel',
+        'lesion_anatomic',
+        'created_at',
+    )  # 목록에 보여줄 필드를 지정합니다.
+    list_filter = (
+        'agreement',
+        'quality',
+        'evaluator',
+        'lesion_vessel',
+        'lesion_anatomic',
+    )  # 필터링할 필드를 지정합니다.
     search_fields = ('inference_result__solution_name', 'evaluator__username') # 관련된 모델의 필드로도 검색할 수 있습니다.

--- a/llm_env/evaluation/migrations/0002_add_lesion_fields.py
+++ b/llm_env/evaluation/migrations/0002_add_lesion_fields.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('evaluation', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='evaluation',
+            name='lesion_vessel',
+            field=models.CharField(max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name='evaluation',
+            name='lesion_anatomic',
+            field=models.CharField(max_length=255, blank=True),
+        ),
+    ]

--- a/llm_env/evaluation/models.py
+++ b/llm_env/evaluation/models.py
@@ -16,6 +16,8 @@ class Evaluation(models.Model):
     agreement = models.CharField(max_length=1, choices=[('O', 'O'), ('X', 'X')])
     quality = models.IntegerField()  # 1점에서 5점까지 저장
     comment = models.TextField(blank=True) # 코멘트는 비어있을 수 있음
+    lesion_vessel = models.CharField(max_length=255, blank=True)
+    lesion_anatomic = models.CharField(max_length=255, blank=True)
     
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -60,10 +60,82 @@
                     </div>
                 </div>
             </div>
-            <div class="card mb-3"><div class="card-header fw-bold">Image</div><div class="card-body"><div class="row">{% for url in display_image_urls %}<div class="col-md-4 mb-3 d-flex justify-content-center align-items-center"><img src="{{ url }}" class="img-fluid rounded img-thumbnail-clickable" alt="Evaluation Image"></div>{% empty %}<p class="text-center text-muted">표시할 이미지가 없습니다.</p>{% endfor %}</div></div></div>
-            <div class="card mb-3"><div class="card-header fw-bold">LLM Result</div><div class="card-body"><pre><code>{{ llm_result_formatted }}</code></pre></div></div>
-            
-            <form action="{% url 'submit_evaluation' selected_id %}" method="post"><div class="evaluation-box">{% csrf_token %}<div><label class="form-label">Agreement</label><div class="btn-group" role="group"><input type="radio" class="btn-check" name="agreement" id="agreement-o" value="O" autocomplete="off" required {% if user_evaluation.agreement == 'O' %}checked{% endif %}><label class="btn btn-outline-success" for="agreement-o">O</label><input type="radio" class="btn-check" name="agreement" id="agreement-x" value="X" autocomplete="off" required {% if user_evaluation.agreement == 'X' %}checked{% endif %}><label class="btn btn-outline-danger" for="agreement-x">X</label></div></div><div><label class="form-label">Quality</label><input type="hidden" name="quality" id="quality-rating" value="{{ user_evaluation.quality|default:'' }}" required><div class="rating-stars h4 m-0"><i class="fa-solid fa-star" data-value="1"></i><i class="fa-solid fa-star" data-value="2"></i><i class="fa-solid fa-star" data-value="3"></i><i class="fa-solid fa-star" data-value="4"></i><i class="fa-solid fa-star" data-value="5"></i></div></div><div class="flex-grow-1"><label class="form-label">Comment</label><input type="text" class="form-control" name="comment" placeholder="Comment" value="{{ user_evaluation.comment|default:'' }}"></div><div><label class="form-label d-block" style="opacity: 0;">.</label><button type="submit" class="btn btn-primary">Submit</button></div></div></form>
+            <form action="{% url 'submit_evaluation' selected_id %}" method="post">
+                <div class="evaluation-box">
+                    {% csrf_token %}
+                    <div>
+                        <label class="form-label">Agreement</label>
+                        <div class="btn-group" role="group">
+                            <input type="radio" class="btn-check" name="agreement" id="agreement-o" value="O" autocomplete="off" required {% if user_evaluation.agreement == 'O' %}checked{% endif %}>
+                            <label class="btn btn-outline-success" for="agreement-o">O</label>
+                            <input type="radio" class="btn-check" name="agreement" id="agreement-x" value="X" autocomplete="off" required {% if user_evaluation.agreement == 'X' %}checked{% endif %}>
+                            <label class="btn btn-outline-danger" for="agreement-x">X</label>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="form-label">Quality</label>
+                        <input type="hidden" name="quality" id="quality-rating" value="{{ user_evaluation.quality|default:'' }}" required>
+                        <div class="rating-stars h4 m-0">
+                            <i class="fa-solid fa-star" data-value="1"></i>
+                            <i class="fa-solid fa-star" data-value="2"></i>
+                            <i class="fa-solid fa-star" data-value="3"></i>
+                            <i class="fa-solid fa-star" data-value="4"></i>
+                            <i class="fa-solid fa-star" data-value="5"></i>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="form-label">병변위치(Vessel)</label>
+                        <input type="text" class="form-control" name="lesion_vessel" placeholder="Vessel" value="{{ user_evaluation.lesion_vessel|default:'' }}">
+                    </div>
+                    <div>
+                        <label class="form-label">병변위치(Anatomic)</label>
+                        <input type="text" class="form-control" name="lesion_anatomic" placeholder="Anatomic" value="{{ user_evaluation.lesion_anatomic|default:'' }}">
+                    </div>
+                    <div class="flex-grow-1">
+                        <label class="form-label">Comment</label>
+                        <input type="text" class="form-control" name="comment" placeholder="Comment" value="{{ user_evaluation.comment|default:'' }}">
+                    </div>
+                    <div>
+                        <label class="form-label d-block" style="opacity: 0;">.</label>
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+            </form>
+
+            <div class="accordion mb-3" id="detailAccordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="headingImage">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImage" aria-expanded="false" aria-controls="collapseImage">
+                            Image
+                        </button>
+                    </h2>
+                    <div id="collapseImage" class="accordion-collapse collapse" aria-labelledby="headingImage" data-bs-parent="#detailAccordion">
+                        <div class="accordion-body">
+                            <div class="row">
+                                {% for url in display_image_urls %}
+                                    <div class="col-md-4 mb-3 d-flex justify-content-center align-items-center">
+                                        <img src="{{ url }}" class="img-fluid rounded img-thumbnail-clickable" alt="Evaluation Image">
+                                    </div>
+                                {% empty %}
+                                    <p class="text-center text-muted">표시할 이미지가 없습니다.</p>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header" id="headingLLM">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLLM" aria-expanded="false" aria-controls="collapseLLM">
+                            LLM Result
+                        </button>
+                    </h2>
+                    <div id="collapseLLM" class="accordion-collapse collapse" aria-labelledby="headingLLM" data-bs-parent="#detailAccordion">
+                        <div class="accordion-body">
+                            <pre><code>{{ llm_result_formatted }}</code></pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
             
             {% else %}
             <div class="d-flex justify-content-center align-items-center" style="min-height: 50vh;"><div class="text-center p-5 bg-light rounded"><h2>데이터가 없습니다.</h2><p class="text-muted">CSV 파일을 업로드하거나 목록에서 항목을 선택해주세요.</p></div></div>

--- a/llm_env/evaluation/views.py
+++ b/llm_env/evaluation/views.py
@@ -152,6 +152,8 @@ def submit_evaluation(request, pk):
     agreement = request.POST.get('agreement')
     quality = request.POST.get('quality')
     comment = request.POST.get('comment', '') # 코멘트는 없을 수도 있음
+    lesion_vessel = request.POST.get('lesion_vessel', '')
+    lesion_anatomic = request.POST.get('lesion_anatomic', '')
 
     # 필수 값들이 있는지 확인
     if not agreement or not quality:
@@ -166,6 +168,8 @@ def submit_evaluation(request, pk):
             'agreement': agreement,
             'quality': int(quality),
             'comment': comment,
+            'lesion_vessel': lesion_vessel,
+            'lesion_anatomic': lesion_anatomic,
         }
     )
 
@@ -195,6 +199,8 @@ def download_paired_results(request):
                 "agreement",
                 "quality",
                 "comment",
+                "lesion_vessel",
+                "lesion_anatomic",
                 "created_at",
             ]
         )
@@ -215,6 +221,8 @@ def download_paired_results(request):
                     eva.agreement,
                     eva.quality,
                     eva.comment,
+                    eva.lesion_vessel,
+                    eva.lesion_anatomic,
                     eva.created_at.isoformat(),
                 ]
             )


### PR DESCRIPTION
## Summary
- add `lesion_vessel` and `lesion_anatomic` fields on `Evaluation`
- include these fields in admin and CSV export
- allow submitting lesion locations on evaluation page
- move evaluation box above image section and collapse image & LLM result
- create migration for new fields

## Testing
- `python -m py_compile llm_env/evaluation/models.py llm_env/evaluation/views.py llm_env/evaluation/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_68817c4e35ec832289955bc9e1f91774