### PR TITLE
Fix redirect import in evaluation views

### DIFF
--- a/llm_env/evaluation/views.py
+++ b/llm_env/evaluation/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, redirect
 from django.contrib.auth.decorators import login_required  # 로그인 여부 확인
 from django.views.decorators.http import require_POST
 from django.core.paginator import Paginator


### PR DESCRIPTION
## Summary
- fix NameError due to missing `redirect` import in evaluation views

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6881880972e48322b34e9f175d06ea55