### PR TITLE
Fix evaluation layout

### DIFF
--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -14,6 +14,7 @@
         .accordion-button:not(.collapsed) { background-color: #e7f1ff; color: #0c63e4; }
         .list-group-item.active { background-color: #0d6efd; border-color: #0d6efd; z-index: 2; }
         .evaluation-box { display: flex; align-items: center; gap: 1.5rem; background-color: #fff; padding: 1rem; border-radius: 0.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); }
+        .sticky-section { position: sticky; top: 0; z-index: 1020; }
         .evaluation-box .form-label { margin-bottom: 0.25rem; font-weight: bold; font-size: 0.9rem; }
         .rating-stars { cursor: pointer; color: #ccc; }
         .rating-stars .fa-star:hover, .rating-stars .fa-star.selected { color: #ffc107; }
@@ -61,7 +62,7 @@
                 </div>
             </div>
             <form action="{% url 'submit_evaluation' selected_id %}" method="post">
-                <div class="evaluation-box">
+                <div class="evaluation-box sticky-section">
                     {% csrf_token %}
                     <div>
                         <label class="form-label">Agreement</label>
@@ -105,11 +106,11 @@
             <div class="accordion mb-3" id="detailAccordion">
                 <div class="accordion-item">
                     <h2 class="accordion-header" id="headingImage">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImage" aria-expanded="false" aria-controls="collapseImage">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseImage" aria-expanded="true" aria-controls="collapseImage">
                             Image
                         </button>
                     </h2>
-                    <div id="collapseImage" class="accordion-collapse collapse" aria-labelledby="headingImage" data-bs-parent="#detailAccordion">
+                    <div id="collapseImage" class="accordion-collapse collapse show" aria-labelledby="headingImage" data-bs-parent="#detailAccordion">
                         <div class="accordion-body">
                             <div class="row">
                                 {% for url in display_image_urls %}
@@ -125,11 +126,11 @@
                 </div>
                 <div class="accordion-item">
                     <h2 class="accordion-header" id="headingLLM">
-                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLLM" aria-expanded="false" aria-controls="collapseLLM">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLLM" aria-expanded="true" aria-controls="collapseLLM">
                             LLM Result
                         </button>
                     </h2>
-                    <div id="collapseLLM" class="accordion-collapse collapse" aria-labelledby="headingLLM" data-bs-parent="#detailAccordion">
+                    <div id="collapseLLM" class="accordion-collapse collapse show" aria-labelledby="headingLLM" data-bs-parent="#detailAccordion">
                         <div class="accordion-body">
                             <pre><code>{{ llm_result_formatted }}</code></pre>
                         </div>
@@ -143,7 +144,7 @@
         </main>
         
         <aside class="col-md-3">
-            <div class="card">
+            <div class="card sticky-section">
                 <div class="card-header fw-bold">LLM Inference list</div>
                 <ul class="list-group list-group-flush">
                 {% for item in page_obj %}


### PR DESCRIPTION
## Summary
- keep Image and LLM Result sections expanded by default
- make evaluation form and LLM Inference list sticky while scrolling

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688188e85114832287525cff5f01bedc