### PR TITLE
Skip PNG conversions if file exists

### DIFF
--- a/dicom_project_template/image_processing.py
+++ b/dicom_project_template/image_processing.py
@@ -83,13 +83,17 @@ def process_row(row: pd.Series, output_dir: Path) -> None:
     os.makedirs(dir_path, exist_ok=True)
 
     if "NCCT" in row["modality"]:
-        non_mask(row["file"], dir_path)
+        nm_path = dir_path / "Non_mask" / "non_mask.png"
+        if not nm_path.exists():
+            non_mask(row["file"], dir_path)
     else:
         for idx, f in enumerate(row["JLK_AI_full_dcm"]):
             sub_path = dir_path / row["modality"]
             os.makedirs(sub_path, exist_ok=True)
             fname = Path(f).stem + f"_{idx}.png"
             save_path = sub_path / fname
+            if save_path.exists():
+                continue
             dicom_to_png(Path(f), save_path)
 
 


### PR DESCRIPTION
## Summary
- avoid redundant PNG conversion in `process_row`

## Testing
- `python manage.py test` *(fails: Missing Django dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6881e6800f1c83228308423cce7c4d53