### PR TITLE
Add zip upload inference view

### DIFF
--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -41,6 +41,7 @@
                 <span class="me-3">Welcome, {{ user.username }}!</span>
                 <a href="{% url 'inference:inference_form' %}" class="btn btn-sm btn-secondary me-2">Inference Page</a>
                 <a href="{% url 'inference:upload_csv' %}" class="btn btn-sm btn-info me-2">Upload CSV</a>
+                <a href="{% url 'inference:upload_zip' %}" class="btn btn-sm btn-warning me-2">Upload ZIP</a>
                 {% if user.is_staff %}
                     <a href="{% url 'download_paired_results' %}" class="btn btn-sm btn-success me-2">Download Data</a>
                 {% endif %}

--- a/llm_env/inference/templates/inference/evaluation.html
+++ b/llm_env/inference/templates/inference/evaluation.html
@@ -12,6 +12,9 @@
             <a href="{% url 'inference:upload_csv' %}" class="btn btn-primary">
                 <i class="fas fa-upload mr-1"></i> Upload Data
             </a>
+            <a href="{% url 'inference:upload_zip' %}" class="btn btn-warning ms-2">
+                <i class="fas fa-file-archive mr-1"></i> Upload ZIP
+            </a>
             <a href="{% url 'inference:inference_form' %}" class="btn btn-info">
                 <i class="fas fa-play mr-1"></i> Run Inference
             </a>
@@ -82,7 +85,8 @@
                             <td colspan="6" class="text-center p-5">
                                 <p class="h4">No Data Available</p>
                                 <p>표시할 결과가 없습니다. 먼저 CSV 파일을 업로드해주세요.</p>
-                                <a href="{% url 'inference:upload_csv' %}" class="btn btn-primary mt-2">Upload First Data</a>
+                                <a href="{% url 'inference:upload_csv' %}" class="btn btn-primary mt-2 me-2">Upload CSV</a>
+                                <a href="{% url 'inference:upload_zip' %}" class="btn btn-warning mt-2">Upload ZIP</a>
                             </td>
                         </tr>
                         {% endfor %}

--- a/llm_env/inference/templates/inference/upload_zip.html
+++ b/llm_env/inference/templates/inference/upload_zip.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>ZIP Upload</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header bg-primary text-white">
+                    <h1 class="h3 mb-0">Upload ZIP File</h1>
+                </div>
+                <div class="card-body">
+                    {% if error %}
+                        <div class="alert alert-danger">{{ error }}</div>
+                    {% endif %}
+                    <form method="post" enctype="multipart/form-data">
+                        {% csrf_token %}
+                        <div class="mb-3">
+                            <label for="zip_file" class="form-label">ZIP 파일 선택</label>
+                            <input class="form-control" type="file" id="zip_file" name="zip_file" accept=".zip">
+                        </div>
+                        <button type="submit" class="btn btn-primary">업로드</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/llm_env/inference/urls.py
+++ b/llm_env/inference/urls.py
@@ -1,7 +1,7 @@
 # llm_env/inference/urls.py
 
 from django.urls import path
-from .views import UploadCsvView, InferenceView
+from .views import UploadCsvView, UploadZipView, InferenceView
 # 제가 이전에 EvaluationView를 이 파일에 추가하라고 안내드렸을 수 있으나,
 # evaluation 앱으로 옮기는 것이 더 정확한 구조입니다.
 # from .views import EvaluationView 
@@ -9,6 +9,7 @@ from .views import UploadCsvView, InferenceView
 app_name = 'inference'
 urlpatterns = [
     path('upload/', UploadCsvView.as_view(), name='upload_csv'),
+    path('upload_zip/', UploadZipView.as_view(), name='upload_zip'),
     
     # ▼▼▼ 아래 줄에서 name='inference'를 name='inference_form'으로 수정합니다. ▼▼▼
     path('inference/', InferenceView.as_view(), name='inference_form'),

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -167,6 +167,12 @@ class UploadZipView(View):
             except Exception as e:  # pragma: no cover - runtime safeguard
                 logger.error("LLM_main execution failed: %s", e, exc_info=True)
 
+        # cleanup extracted data regardless of success
+        extract_dir = Path(saved_path).with_suffix("")
+        output_dir = Path(settings.BASE_DIR) / f"{Path(saved_path).stem}_output_images"
+        shutil.rmtree(extract_dir, ignore_errors=True)
+        shutil.rmtree(output_dir, ignore_errors=True)
+
         for item in results:
             try:
                 solution_name = item.get('solution', '')
@@ -181,6 +187,8 @@ class UploadZipView(View):
 
                 InferenceResult.objects.create(
                     solution_name=solution_name,
+                    system_prompt="기존과 동일",
+                    user_prompt="기존과 동일",
                     llm_output=output,
                 )
             except Exception as e:

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -29,9 +29,18 @@ from django.db.models import Case, When, Value, IntegerField
 from .models import InferenceResult
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
+from pathlib import Path
+import sys
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO) # INFO 레벨 이상의 로그를 출력하도록 설정
+
+# Add dicom_project_template path for zip processing
+sys.path.append(str(Path(settings.BASE_DIR).parent / 'dicom_project_template'))
+try:
+    from LLM_main import main as dicom_llm_main
+except Exception:  # pragma: no cover - import may fail during tests without package
+    dicom_llm_main = None
 
 @method_decorator(login_required, name='dispatch')
 class UploadCsvView(View):
@@ -129,6 +138,53 @@ class UploadCsvView(View):
         except Exception as e:
             logger.error(f"파일 처리 중 예측하지 못한 최상위 오류 발생: {e}", exc_info=True)
             return render(request, 'inference/upload_csv.html', {'error': f'파일 처리 중 예측하지 못한 오류 발생: {e}'})
+
+        return redirect('evaluation')
+
+@method_decorator(login_required, name='dispatch')
+class UploadZipView(View):
+    """Handle ZIP uploads and run dicom processing"""
+
+    def get(self, request, *args, **kwargs):
+        return render(request, 'inference/upload_zip.html')
+
+    def post(self, request, *args, **kwargs):
+        uploaded = request.FILES.get('zip_file')
+        if not uploaded:
+            return render(request, 'inference/upload_zip.html', {'error': '파일을 업로드해주세요.'})
+
+        upload_dir = os.path.join(settings.MEDIA_ROOT, 'zip_uploads')
+        os.makedirs(upload_dir, exist_ok=True)
+        saved_path = os.path.join(upload_dir, uploaded.name)
+        with open(saved_path, 'wb+') as dest:
+            for chunk in uploaded.chunks():
+                dest.write(chunk)
+
+        results = []
+        if dicom_llm_main:
+            try:
+                results = dicom_llm_main(saved_path) or []
+            except Exception as e:  # pragma: no cover - runtime safeguard
+                logger.error("LLM_main execution failed: %s", e, exc_info=True)
+
+        for item in results:
+            try:
+                solution_name = item.get('solution', '')
+                output_raw = item.get('result', {})
+                if isinstance(output_raw, str):
+                    try:
+                        output = json.loads(output_raw)
+                    except json.JSONDecodeError:
+                        output = {}
+                else:
+                    output = output_raw
+
+                InferenceResult.objects.create(
+                    solution_name=solution_name,
+                    llm_output=output,
+                )
+            except Exception as e:
+                logger.error("Failed to save result: %s", e, exc_info=True)
 
         return redirect('evaluation')
 


### PR DESCRIPTION
## Summary
- allow uploading ZIP archives for inference results
- wire up new route under `inference:upload_zip`
- create simple upload form template
- link to ZIP upload page from evaluation pages

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6881f52cdbf88322be11532d3cdf3695