### PR TITLE
Fix local imports in dicom project

### DIFF
--- a/llm_env/dicom_project_template/LLM_main.py
+++ b/llm_env/dicom_project_template/LLM_main.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from dataset_utils import _collection_path
-from file_utils import extract_zip
-from image_processing import convert_all_dicom_to_png_parallel
-from openai_utils import JLK_ICH, JLK_CTL, JLK_CTI, JLK_WMHC
+from .dataset_utils import _collection_path
+from .file_utils import extract_zip
+from .image_processing import convert_all_dicom_to_png_parallel
+from .openai_utils import JLK_ICH, JLK_CTL, JLK_CTI, JLK_WMHC
 from tqdm import tqdm
 
 

--- a/llm_env/dicom_project_template/image_processing.py
+++ b/llm_env/dicom_project_template/image_processing.py
@@ -8,8 +8,8 @@ import pydicom
 from PIL import Image
 from tqdm import tqdm
 
-from CT_Preprocessing import PreprocessingCTImage as pp
-from utils import draw_overlay_cti
+from .CT_Preprocessing import PreprocessingCTImage as pp
+from .utils import draw_overlay_cti
 
 
 def normalize_to_8bit(array: np.ndarray) -> np.ndarray:

--- a/llm_env/dicom_project_template/openai_utils.py
+++ b/llm_env/dicom_project_template/openai_utils.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from PIL import Image
 
-from report_models import ImagingReport
+from .report_models import ImagingReport
 from dotenv import load_dotenv
 load_dotenv() 
 try:  # Optional dependency

--- a/llm_env/dicom_project_template/utils.py
+++ b/llm_env/dicom_project_template/utils.py
@@ -21,11 +21,11 @@ from matplotlib.lines import Line2D
 from matplotlib.font_manager import FontProperties
 from collections.abc import Iterable
 
-from CT_Preprocessing import PreprocessingCTImage as pp
-from CT_Preprocessing import window_image, normalize_array
+from .CT_Preprocessing import PreprocessingCTImage as pp
+from .CT_Preprocessing import window_image, normalize_array
 
 
-from Visualization import plot_settings, ROUND_SQAURE
+from .Visualization import plot_settings, ROUND_SQAURE
 
 
 


### PR DESCRIPTION
## Summary
- use relative imports within `dicom_project_template`

## Testing
- `python llm_env/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6881fb6775408322bc962f67110f4765