### PR TITLE
Fix image display for uploaded DICOM zips

### DIFF
--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -205,6 +205,14 @@ class UploadZipView(View):
                     else:
                         output = output_raw
 
+                    # Preserve image directory information so the evaluation page
+                    # can display generated images.
+                    if isinstance(output, dict):
+                        if item.get('non_mask_dir'):
+                            output['non_mask_dir'] = item.get('non_mask_dir')
+                        if item.get('ai_dir'):
+                            output['ai_dir'] = item.get('ai_dir')
+
                     output = update_paths(output)
 
                     InferenceResult.objects.create(


### PR DESCRIPTION
## Summary
- preserve `non_mask_dir` and `ai_dir` paths when saving inference results

## Testing
- `python -m py_compile llm_env/inference/views.py`


------
https://chatgpt.com/codex/tasks/task_e_68820c5c2d948322bd58b216a8ec3db4