### PR TITLE
Create output under media

### DIFF
--- a/llm_env/dicom_project_template/LLM_main.py
+++ b/llm_env/dicom_project_template/LLM_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import os
 
 from .dataset_utils import _collection_path
 from .file_utils import extract_zip
@@ -40,8 +41,17 @@ def run_jlk_solutions(non_mask_dir: Path, item: Path) -> list[dict]:
     return results
 
 
-def main(zip_file) -> None:
-    """Example main routine."""
+def main(zip_file, output_root: str | Path = "/media/dicom_outputs") -> None:
+    """Run the DICOM to PNG pipeline and JLK solutions.
+
+    Parameters
+    ----------
+    zip_file : str | Path
+        Path to the uploaded zip file.
+    output_root : str | Path, optional
+        Directory under which the output images will be stored. Defaults to
+        ``/media/dicom_outputs``.
+    """
 
     zip_path = Path(zip_file)
     extract_path = extract_zip(zip_path)
@@ -49,8 +59,13 @@ def main(zip_file) -> None:
         return
 
     df = _collection_path(extract_path)
-    output_dir = Path(f"{Path(zip_file).stem}_output_images")
-    convert_all_dicom_to_png_parallel(df, output_dir)
+
+    output_root = Path(output_root)
+    os.makedirs(output_root, exist_ok=True)
+    output_dir = output_root / f"{zip_path.stem}_output_images"
+
+    if not output_dir.exists():
+        convert_all_dicom_to_png_parallel(df, output_dir)
 
     AI_result = []
     for item in tqdm(list(output_dir.iterdir())[:3]):
@@ -61,4 +76,7 @@ def main(zip_file) -> None:
 
     return AI_result
 if __name__ == "__main__":  # pragma: no cover - manual execution
-    rr = main("/home/yjpark/llm_env/dicom_project_template/DCM_REQUEST_2025-07-23-05-16-58-465027_0.zip")
+    rr = main(
+        "/home/yjpark/llm_env/dicom_project_template/DCM_REQUEST_2025-07-23-05-16-58-465027_0.zip"
+    )
+

--- a/llm_env/inference/views.py
+++ b/llm_env/inference/views.py
@@ -164,23 +164,19 @@ class UploadZipView(View):
         shutil.copy2(saved_path, os.path.join(uploads_dir, uploaded.name))
 
         def run_inference(path):
+            media_output_root = Path(settings.MEDIA_ROOT) / "dicom_outputs"
+            os.makedirs(media_output_root, exist_ok=True)
+
             results = []
             if dicom_llm_main:
                 try:
-                    results = dicom_llm_main(path) or []
+                    results = dicom_llm_main(path, output_root=media_output_root) or []
                 except Exception as e:  # pragma: no cover - runtime safeguard
                     logger.error("LLM_main execution failed: %s", e, exc_info=True)
 
             extract_dir = Path(path).with_suffix("")
-            output_dir = Path(settings.BASE_DIR) / f"{Path(path).stem}_output_images"
-
-            media_output_root = Path(settings.MEDIA_ROOT) / "dicom_outputs"
-            os.makedirs(media_output_root, exist_ok=True)
-            moved_output_dir = media_output_root / output_dir.name
-            if output_dir.exists():
-                if moved_output_dir.exists():
-                    shutil.rmtree(moved_output_dir, ignore_errors=True)
-                shutil.move(str(output_dir), moved_output_dir)
+            output_dir = media_output_root / f"{Path(path).stem}_output_images"
+            moved_output_dir = output_dir
 
             shutil.rmtree(extract_dir, ignore_errors=True)
 


### PR DESCRIPTION
## Summary
- generate output images directly under `/media/dicom_outputs`
- make output location configurable in `LLM_main.main`

## Testing
- `python llm_env/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688213f54d448322bb96b99d1d196d40