### PR TITLE
Add date range filtering for evaluation results

### DIFF
--- a/llm_env/evaluation/templates/evaluation/evaluation.html
+++ b/llm_env/evaluation/templates/evaluation/evaluation.html
@@ -164,11 +164,24 @@
         </main>
         
         <aside class="col-md-3">
+            <form method="get" action="{% url 'evaluation' %}" class="card mb-3">
+                <div class="card-body">
+                    <div class="mb-2">
+                        <input type="date" name="start_date" value="{{ start_date }}" class="form-control form-control-sm">
+                    </div>
+                    <div class="mb-2">
+                        <input type="date" name="end_date" value="{{ end_date }}" class="form-control form-control-sm">
+                    </div>
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-sm btn-primary">Filter</button>
+                    </div>
+                </div>
+            </form>
             <div class="card sticky-section">
                 <div class="card-header fw-bold">LLM Inference list</div>
                 <ul class="list-group list-group-flush">
                 {% for item in page_obj %}
-                    <a href="{% url 'evaluation_detail' item.pk %}?page={{ page_obj.number }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {% if item.pk == selected_id %}active{% endif %}">
+                    <a href="{% url 'evaluation_detail' item.pk %}?page={{ page_obj.number }}{{ extra_query }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center {% if item.pk == selected_id %}active{% endif %}">
                         <span class="d-flex align-items-center" style="font-size: 0.9rem;">
                             {% if item.pk in evaluated_ids %}
                                 <i class="fa-solid fa-check-circle text-success me-2" title="평가 완료"></i>
@@ -190,7 +203,29 @@
                 {% endfor %}
                 </ul>
 
-                {% if page_obj.has_other_pages %}<div class="card-footer"><nav aria-label="Page navigation"><ul class="pagination pagination-sm justify-content-center m-0">{% if page_obj.has_previous %}<li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page=1{% else %}?page=1{% endif %}">&laquo;</a></li><li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page={{ page_obj.previous_page_number }}{% else %}?page={{ page_obj.previous_page_number }}{% endif %}">이전</a></li>{% else %}<li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li><li class="page-item disabled"><a class="page-link" href="#">이전</a></li>{% endif %}<li class="page-item active" aria-current="page"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>{% if page_obj.has_next %}<li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page={{ page_obj.next_page_number }}{% else %}?page={{ page_obj.next_page_number }}{% endif %}">다음</a></li><li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page={{ page_obj.paginator.num_pages }}{% else %}?page={{ page_obj.paginator.num_pages }}{% endif %}">&raquo;</a></li>{% else %}<li class="page-item disabled"><a class="page-link" href="#">다음</a></li><li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>{% endif %}</ul></nav></div>{% endif %}
+                {% if page_obj.has_other_pages %}
+                <div class="card-footer">
+                    <nav aria-label="Page navigation">
+                        <ul class="pagination pagination-sm justify-content-center m-0">
+                            {% if page_obj.has_previous %}
+                            <li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page=1{{ extra_query }}{% else %}?page=1{{ extra_query }}{% endif %}">&laquo;</a></li>
+                            <li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page={{ page_obj.previous_page_number }}{{ extra_query }}{% else %}?page={{ page_obj.previous_page_number }}{{ extra_query }}{% endif %}">이전</a></li>
+                            {% else %}
+                            <li class="page-item disabled"><a class="page-link" href="#">&laquo;</a></li>
+                            <li class="page-item disabled"><a class="page-link" href="#">이전</a></li>
+                            {% endif %}
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span></li>
+                            {% if page_obj.has_next %}
+                            <li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page={{ page_obj.next_page_number }}{{ extra_query }}{% else %}?page={{ page_obj.next_page_number }}{{ extra_query }}{% endif %}">다음</a></li>
+                            <li class="page-item"><a class="page-link" href="{% if selected_id %}{% url 'evaluation_detail' selected_id %}?page={{ page_obj.paginator.num_pages }}{{ extra_query }}{% else %}?page={{ page_obj.paginator.num_pages }}{{ extra_query }}{% endif %}">&raquo;</a></li>
+                            {% else %}
+                            <li class="page-item disabled"><a class="page-link" href="#">다음</a></li>
+                            <li class="page-item disabled"><a class="page-link" href="#">&raquo;</a></li>
+                            {% endif %}
+                        </ul>
+                    </nav>
+                </div>
+                {% endif %}
             </div>
         </aside>
     </div>

--- a/llm_env/evaluation/tests.py
+++ b/llm_env/evaluation/tests.py
@@ -1,3 +1,36 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from datetime import timedelta
+from django.contrib.auth.models import User
+from inference.models import InferenceResult
 
-# Create your tests here.
+
+class EvaluationFilterTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass")
+        self.client.login(username="tester", password="pass")
+
+        self.old_result = InferenceResult.objects.create(
+            system_prompt="",
+            user_prompt="old",
+            image_urls=[],
+            llm_output={},
+            solution_name="old",
+        )
+        self.old_result.created_at = timezone.now() - timedelta(days=10)
+        self.old_result.save(update_fields=["created_at"])
+
+        self.new_result = InferenceResult.objects.create(
+            system_prompt="",
+            user_prompt="new",
+            image_urls=[],
+            llm_output={},
+            solution_name="new",
+        )
+
+    def test_evaluation_list_filters_by_date(self):
+        start = (timezone.now() - timedelta(days=1)).date().isoformat()
+        response = self.client.get(reverse("evaluation") + f"?start_date={start}")
+        expected_url = reverse("evaluation_detail", args=[self.new_result.pk]) + f"?start_date={start}"
+        self.assertRedirects(response, expected_url)


### PR DESCRIPTION
## Summary
- Allow filtering inference results by start and end dates in evaluation views
- Add date range form to evaluation page and preserve filters across pagination
- Test that evaluation list redirects to items within specified period

## Testing
- `python llm_env/manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68903b6147c883229b1d76b9b1b3c903